### PR TITLE
Generate files only when necessary

### DIFF
--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -72,17 +72,17 @@ pub fn init() {
         } else {
             touch(Path::new(".env")).unwrap();
         }
-    }
-    if !path_exists(".env.production") {
-        touch(Path::new(".env.production")).unwrap();
-        if path_exists(".env.example") {
-            check(EnvFile::read(PathBuf::from(".env.example")), vec![
-                EnvFile::read(PathBuf::from(".env.production")),
-            ], CheckOptions { force: true, quiet: true });
+        if !path_exists(".env.production") {
+            touch(Path::new(".env.production")).unwrap();
+            if path_exists(".env.example") {
+                check(EnvFile::read(PathBuf::from(".env.example")), vec![
+                    EnvFile::read(PathBuf::from(".env.production")),
+                ], CheckOptions { force: true, quiet: true });
+            }
         }
-    }
-    if !path_exists(".env.example") {
-        touch(Path::new(".env.example")).unwrap();
+        if !path_exists(".env.example") {
+            touch(Path::new(".env.example")).unwrap();
+        }
     }
 }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -42,16 +42,21 @@ fn find_gitignore() -> PathBuf {
     PathBuf::from_str(".gitignore").unwrap()
 }
 
+const DEFAULT_GITIGNORE_RULES: &str = "
+.env*
+!.env.example
+";
+
 pub fn init() {
     let gitignore_path = find_gitignore();
     let gitignore_content = fs::read_to_string(&gitignore_path).unwrap();
     if gitignore_content.contains(".env") {
+        // Frameworks with conventions about .env files 
+        // (eg Next.js that tracks .env but not .env.local)
+        // are expected to set their .gitignore properly in the first place
         eprintln!("{}: .gitignore already contains dotenv rules. Skipping addition of rules.", gitignore_path.display());
     } else {
-        append(&find_gitignore(), "
-.env*
-!.env.example
-").unwrap();
+        append(&find_gitignore(), DEFAULT_GITIGNORE_RULES).unwrap();
     }
 
     if !path_exists(".env") {


### PR DESCRIPTION
Hi,
Some frameworks like Next.js are expected to have weird conventions.
In Next (v12.3 at the time of writing), ".env", ".env.development", ".env.production" and ".env.test" are *tracked* files, and ".env*.local" are *untracked* files.

Currently, "modenv" will generate ".env.production" and ".env.example" if they do not exists, but these files do not make sense in Next.js (and maybe other frameworks).

So what I propose:
- if the project has a .gitignore that matches at least one ".env" rule, we consider tracking to be set, do not touch it => already done
- if the project has a ".env" file, we consider files to be set, do not generate anything => this is more framework agnostic, as we suppose that if there is already a .env, it means that .env files already has been set. 

*Specific scenario*: In Next.js for instance, ".env"/".env.local" are equivalent to ".env.example"/".env" in other projects. In Remix, the initalization is handled by a custom script specific to each stack, so we don't need modenv eitther.
*Normal scenario*: It will still work for other projects where there is no ".env" set as a default or just a ".env.example" the normal workflow happens, generating ".env", ".env.example" and ".env.production"

A small thing that bugged me: the code is different for generating ".env" or ".env.production" based on ".env.example", why? It seems the logic is the same but you use 2 different way, the ".env.production" code is terser.

Another Rust related thing: do you use `&str` or `&'static str` for global string values?